### PR TITLE
Fix stale username failing test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -84,7 +84,7 @@ class TestScraper(unittest.TestCase):
             self.assertTrue("red" in list_.title.lower())
 
     def test_user_search(self):
-        user = sfpl.User("Sublurbanite")
+        user = sfpl.User("SFPL_ReadersAdvisory")
 
         user.getFollowers()
         user.getFollowing()


### PR DESCRIPTION
Fix stale username failing test

* Use "SFPL_ReadersAdvisory" as this is a staff account and unlikely to be deleted soon